### PR TITLE
Branch previews

### DIFF
--- a/.github/workflows/algolia-search.yml
+++ b/.github/workflows/algolia-search.yml
@@ -1,5 +1,7 @@
 on:
-  page_build:
+  push:
+    branches:
+      - main
 
 name: algolia-search
 jobs:
@@ -21,6 +23,6 @@ jobs:
             ${{ runner.os }}-gems-
             
       - name: Algolia Jekyll Action
-        uses: dieghernan/algolia-jekyll-action@v1
+        uses: dieghernan/algolia-jekyll-action@v2
         with:
           APIKEY: '${{ secrets.ALGOLIA_API_KEY }}'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,8 +15,10 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "::set-output name=directory::main"
+            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/main"
           else
             echo "::set-output name=directory::pr-preview/pr-${{ github.ref }}"
+            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/pr-preview/pr-${{ github.ref }}"
           fi
       - name: Set Jekyll base url
         uses: fjogeleit/yaml-update-action@main
@@ -32,6 +34,13 @@ jobs:
         uses: actions/jekyll-build-pages@v1
         with:
           destination: ./build
+      - name: Start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ github.ref }}
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -40,3 +49,13 @@ jobs:
           publish_dir: ./build
           destination_dir: ${{ steps.github-pages.outputs.directory }}
           enable_jekyll: false
+      - name: Update deployment status
+        uses: bobheadxi/deployments@v1
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ steps.github-pages.outputs.url }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,14 +3,18 @@ name: Deploy Jekyll site to GitHub Pages
 on:
   push:
     branches: ["*"]
+  delete:
+    branches: ["*"]
 
 env:
+  GITHUB_PAGES_BRANCH: "gh-pages"
   BUILD_DIR: "./build"
   REPO_NAME: 'folkebibliotekernes_cms_manual'
   PREVIEW_SUBDIR: 'preview'
 
 jobs:
   build:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,7 +57,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
+          publish_branch: ${{ env.GITHUB_PAGES_BRANCH }}
           publish_dir: ${{ env.BUILD_DIR }}
           destination_dir: ${{ steps.github-pages.outputs.directory }}
           enable_jekyll: false
@@ -67,3 +71,26 @@ jobs:
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ steps.github-pages.outputs.url }}
+
+  delete:
+    if: github.event_name == 'delete'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GITHUB_PAGES_BRANCH }}
+      # We cannot use tj-actions/branch-names to get the name of the deleted
+      # branch as it will already be deleted when this runs.
+      - name: Delete preview
+        run: |
+          rm -rf ${{ env.PREVIEW_SUBDIR }}/${{ github.event.ref }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Delete preview for ${{ github.event.ref }}"
+      - name: Close environment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: deactivate-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ github.event.ref }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set GitHub Pages directory
+        id: github-pages
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "::set-output name=directory::main"
+          else
+            echo "::set-output name=directory::pr-preview/pr-${{ github.ref }}"
+          fi
+      - name: Set Jekyll base url
+        uses: fjogeleit/yaml-update-action@main
+        with:
+          valueFile: '_config.yml'
+          propertyPath: 'baseurl'
+          value: '/folkebibliotekernes_cms_manual/${{ steps.github-pages.outputs.directory }}'
+          commitChange: false
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+        with:
+          destination: ./build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build
+          destination_dir: ${{ steps.github-pages.outputs.directory }}
+          enable_jekyll: false

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GITHUB_PAGES_BRANCH: "gh-pages"
+  GITHUB_PAGES_ROOT_DIR: "./gh-pages-root"
   BUILD_DIR: "./build"
   REPO_NAME: 'folkebibliotekernes_cms_manual'
   PREVIEW_SUBDIR: 'preview'
@@ -19,6 +20,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Prepare documentation root
+        run: |
+          mkdir -p ${{ env.GITHUB_PAGES_ROOT_DIR }}
+          echo "<!DOCTYPE html>
+          <html>
+            <head><meta http-equiv=\"refresh\" content=\"0; url='./main/'\" /></head>
+            <body><p>You will be redirected to the documentation</p></body>
+          </html>" > ${{ env.GITHUB_PAGES_ROOT_DIR }}/index.html
+      - name: Deploy documentation root
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: ${{ env.GITHUB_PAGES_BRANCH }}
+          publish_dir: ${{ env.GITHUB_PAGES_ROOT_DIR }}
+          destination_dir: "."
+          keep_files: true
       - name: Get branch names
         id: branch-name
         uses: tj-actions/branch-names@v7

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches: ["*"]
 
+env:
+  REPO_NAME: 'folkebibliotekernes_cms_manual'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v7
       - name: Set GitHub Pages directory
         id: github-pages
         run: |
@@ -17,8 +23,8 @@ jobs:
             echo "::set-output name=directory::main"
             echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/main"
           else
-            echo "::set-output name=directory::pr-preview/pr-${{ github.ref }}"
-            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/pr-preview/pr-${{ github.ref }}"
+            echo "::set-output name=directory::preview/${{ steps.branch-name.outputs.current_branch }}"
+            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/preview/${{ steps.branch-name.outputs.current_branch }}"
           fi
       - name: Set Jekyll base url
         uses: fjogeleit/yaml-update-action@main
@@ -40,7 +46,7 @@ jobs:
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ github.ref }}
+          env: ${{ steps.branch-name.outputs.current_branch }}
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,9 @@ on:
     branches: ["*"]
 
 env:
+  BUILD_DIR: "./build"
   REPO_NAME: 'folkebibliotekernes_cms_manual'
+  PREVIEW_SUBDIR: 'preview'
 
 jobs:
   build:
@@ -21,17 +23,17 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "::set-output name=directory::main"
-            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/main"
+            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/main"
           else
             echo "::set-output name=directory::preview/${{ steps.branch-name.outputs.current_branch }}"
-            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/folkebibliotekernes_cms_manual/preview/${{ steps.branch-name.outputs.current_branch }}"
+            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/${{ env.PREVIEW_SUBDIR }}/${{ steps.branch-name.outputs.current_branch }}"
           fi
       - name: Set Jekyll base url
         uses: fjogeleit/yaml-update-action@main
         with:
           valueFile: '_config.yml'
           propertyPath: 'baseurl'
-          value: '/folkebibliotekernes_cms_manual/${{ steps.github-pages.outputs.directory }}'
+          value: '/${{ env.REPO_NAME }}/${{ steps.github-pages.outputs.directory }}'
           commitChange: false
       - name: Setup Pages
         id: pages
@@ -39,7 +41,7 @@ jobs:
       - name: Build
         uses: actions/jekyll-build-pages@v1
         with:
-          destination: ./build
+          destination: ${{ env.BUILD_DIR }}
       - name: Start deployment
         uses: bobheadxi/deployments@v1
         id: deployment
@@ -52,7 +54,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: ./build
+          publish_dir: ${{ env.BUILD_DIR }}
           destination_dir: ${{ steps.github-pages.outputs.directory }}
           enable_jekyll: false
       - name: Update deployment status

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,11 +45,11 @@ jobs:
         id: github-pages
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "::set-output name=directory::main"
-            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/main"
+            echo "directory=main" >> $GITHUB_OUTPUT
+            echo "url=https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/main" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=directory::preview/${{ steps.branch-name.outputs.current_branch }}"
-            echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/${{ env.PREVIEW_SUBDIR }}/${{ steps.branch-name.outputs.current_branch }}"
+            echo "directory=preview/${{ steps.branch-name.outputs.current_branch }}" >> $GITHUB_OUTPUT
+            echo "url=https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/${{ env.PREVIEW_SUBDIR }}/${{ steps.branch-name.outputs.current_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Configure GitHub Pages
         id: pages

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,10 @@ env:
   REPO_NAME: 'folkebibliotekernes_cms_manual'
   PREVIEW_SUBDIR: 'preview'
 
+permissions:
+  contents: write
+  deployments: write
+
 jobs:
   build:
     name: "Build and deploy Jekyll site"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -61,6 +61,10 @@ jobs:
           publish_dir: ${{ env.BUILD_DIR }}
           destination_dir: ${{ steps.github-pages.outputs.directory }}
           enable_jekyll: false
+      - name: Wait for deployment to become available
+        uses: iFaxity/wait-on-action@v1
+        with:
+          resource: ${{ steps.github-pages.outputs.url }}
       - name: Update deployment status
         uses: bobheadxi/deployments@v1
         if: always()

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to GitHub Pages
+name: GitHub Pages
 
 on:
   push:
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    name: "Build and deploy Jekyll site"
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +50,9 @@ jobs:
             echo "::set-output name=directory::preview/${{ steps.branch-name.outputs.current_branch }}"
             echo "::set-output name=url::https://${{ github.repository_owner }}.github.io/${{ env.REPO_NAME }}/${{ env.PREVIEW_SUBDIR }}/${{ steps.branch-name.outputs.current_branch }}"
           fi
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v3
       - name: Set Jekyll base url
         uses: fjogeleit/yaml-update-action@main
         with:
@@ -56,10 +60,7 @@ jobs:
           propertyPath: 'baseurl'
           value: '/${{ env.REPO_NAME }}/${{ steps.github-pages.outputs.directory }}'
           commitChange: false
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      - name: Build
+      - name: Build Jekyll site
         uses: actions/jekyll-build-pages@v1
         with:
           destination: ${{ env.BUILD_DIR }}
@@ -70,7 +71,7 @@ jobs:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ steps.branch-name.outputs.current_branch }}
-      - name: Deploy
+      - name: Deploy Jekyll site to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +95,7 @@ jobs:
           env_url: ${{ steps.github-pages.outputs.url }}
 
   delete:
+    name: "Cleanup preview"
     if: github.event_name == 'delete'
     runs-on: ubuntu-latest
     steps:
@@ -103,13 +105,13 @@ jobs:
           ref: ${{ env.GITHUB_PAGES_BRANCH }}
       # We cannot use tj-actions/branch-names to get the name of the deleted
       # branch as it will already be deleted when this runs.
-      - name: Delete preview
+      - name: Delete preview site
         run: |
           rm -rf ${{ env.PREVIEW_SUBDIR }}/${{ github.event.ref }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Delete preview for ${{ github.event.ref }}"
-      - name: Close environment
+      - name: Deactivate environment
         uses: bobheadxi/deployments@v1
         with:
           step: deactivate-env

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,6 +37,7 @@ jobs:
           publish_dir: ${{ env.GITHUB_PAGES_ROOT_DIR }}
           destination_dir: "."
           keep_files: true
+          commit_message: "Create root index.html"
       - name: Get branch names
         id: branch-name
         uses: tj-actions/branch-names@v7
@@ -79,6 +80,7 @@ jobs:
           publish_dir: ${{ env.BUILD_DIR }}
           destination_dir: ${{ steps.github-pages.outputs.directory }}
           enable_jekyll: false
+          commit_message: "Create/update Jekyll site for ${{ steps.branch-name.outputs.current_branch }}"
       - name: Wait for deployment to become available
         uses: iFaxity/wait-on-action@v1
         with:
@@ -110,7 +112,7 @@ jobs:
           rm -rf ${{ env.PREVIEW_SUBDIR }}/${{ github.event.ref }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "Delete preview for ${{ github.event.ref }}"
+          commit_message: "Delete preview Jekyll site for ${{ github.event.ref }}"
       - name: Deactivate environment
         uses: bobheadxi/deployments@v1
         with:

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ Der er lavet to små "hacks" til Minimal Mistakes. 
 #### Søgning med Algolia
 
 Søgefeltet i manualen virker med Algolia søgemotor. Der er oprettet et Github Action workflow der sætter reindeksering i gang ved hvert Github Pages rebuild.
+
+#### Forhåndsvisning af ændringer
+
+Når du laver ændringer til manualen i en branch på GitHub bliver der automatisk bygget en version af sitet hvor du kan
+se resultatet. Du kan tilgå forhåndsvisningen på følgende måder:
+
+- Klik på navnet på branchen i listen over environments til højre på repositoriets forside og klik på "View deployment"
+- Under et pull request for branchen klik på "View deployment"

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
+baseurl: "/" # the subpath of your site, e.g. /blog
 minimal_mistakes_skin: default
 search: true
 search_provider: algolia


### PR DESCRIPTION
Add support for previews of branches.

I suggest going through the PR in the following order:

1. Read through the updated documentation
2. Go through the commits one by one and read the commit comments.

The resulting in a PR site can be seen here: https://github.com/kasperg/folkebibliotekernes_cms_manual/pull/5. Apparently deployments are not shown across forks.

<img width="758" alt="folkebibliotekernes_cms_manual 2023-07-05 07-21-08" src="https://github.com/danskernesdigitalebibliotek/folkebibliotekernes_cms_manual/assets/73966/2e975b4f-f084-401a-b280-84a83ec3d2c7">

Two notes:

1. I have not checked whether the Algolia integration still works as I do not have the necessary API codes. I guess we have to do this when this is merged.
2. If we merge this we need to update the repository settings to use a new `gh-pages` branch as the source for GitHub Pages